### PR TITLE
Fix internal wildcard bug

### DIFF
--- a/matchbox_test.go
+++ b/matchbox_test.go
@@ -33,11 +33,11 @@ func (m subscriber) ID() string {
 func TestMatchbox(t *testing.T) {
 	assert := assert.New(t)
 	mb := New(NewAMQPConfig())
-	sub1 := subscriber("abc")
-	sub2 := subscriber("def")
-	sub3 := subscriber("ghi")
-	sub4 := subscriber("jkl")
-	sub5 := subscriber("mno")
+	sub1 := subscriber("sub1")
+	sub2 := subscriber("sub2")
+	sub3 := subscriber("sub3")
+	sub4 := subscriber("sub4")
+	sub5 := subscriber("sub5")
 
 	assert.Equal([]Subscriber{}, mb.Subscribers("foo"))
 	mb.Unsubscribe("moo", sub1)
@@ -95,11 +95,13 @@ func TestMatchbox(t *testing.T) {
 	mb.Unsubscribe("a.b.b.c", sub2)
 	mb.Unsubscribe("a.b.b.c", sub2)
 	assert.Equal([]Subscriber{sub3}, mb.Subscribers("a.b.b.c"))
+	mb.Unsubscribe("a.*.*.c", sub3)
 
 	mb.Subscribe("d.#.f", sub1)
 	assert.Equal([]Subscriber{sub1}, mb.Subscribers("d.f"))
 	assert.Equal([]Subscriber{sub1}, mb.Subscribers("d.e.f"))
 	assert.Equal([]Subscriber{sub1}, mb.Subscribers("d.e.e.e.e.e.f"))
+	mb.Unsubscribe("d.#.f", sub1)
 
 	mb.Subscribe("x.#", sub3)
 	assert.Equal([]Subscriber{sub3}, mb.Subscribers("x"))
@@ -110,6 +112,7 @@ func TestMatchbox(t *testing.T) {
 		assert.Contains(sessions, subscriber)
 	}
 	assert.Equal([]Subscriber{sub3}, mb.Subscribers("x.y.z.z.z.z.z.z.z"))
+	mb.Unsubscribe("x.#", sub3)
 
 	mb.Subscribe("x.#.#.#.y.z", sub4)
 	assert.Equal([]Subscriber{sub4}, mb.Subscribers("x.a.y.z"))
@@ -121,31 +124,32 @@ func TestMatchbox(t *testing.T) {
 	assert.Equal([]Subscriber{}, mb.Subscribers("x.a.a.a.y"))
 }
 
-// Mimic problem that Tom Deering is experiencing
 func TestInternalPoundSubscriber(t *testing.T) {
 	assert := assert.New(t)
 
-	// Works for Tom
-	//mb := New(NewAMQPConfig())
-	//sub1 := subscriber("Subcriber1")
-	//mb.Subscribe("*.b.#", sub1)
-	//sub2 := subscriber("Subscriber2")
-	//mb.Subscribe("*.b.*.d", sub2)
-	//subscribers := mb.Subscribers("a.b.c.d")
-	//sessions := []Subscriber{sub1, sub2}
-	//assert.Len(subscribers, 2)
-	//for _, subscriber := range subscribers {
-	//	assert.Contains(sessions, subscriber)
-	//}
-
-	// Does not work for Tom. He observed that sub1 does not seem to receive
-	// messages in this situation
 	mb := New(NewAMQPConfig())
 	sub1 := subscriber("Subcriber1")
 	mb.Subscribe("*.b.#", sub1)
 	sub2 := subscriber("Subscriber2")
+	mb.Subscribe("*.b.*.d", sub2)
+	subscribers := mb.Subscribers("a.b.c.d")
+	sessions := []Subscriber{sub1, sub2}
+	assert.Len(subscribers, 2)
+	for _, subscriber := range subscribers {
+		assert.Contains(sessions, subscriber)
+	}
+
+	mb = New(NewAMQPConfig())
+	sub1 = subscriber("Subcriber1")
+	mb.Subscribe("*.b.#", sub1)
+	sub2 = subscriber("Subscriber2")
 	mb.Subscribe("*.b.#.d", sub2)
-	assert.Equal([]Subscriber{sub2, sub1}, mb.Subscribers("a.b.c.d"))
+	sessions = []Subscriber{sub1, sub2}
+	subscribers = mb.Subscribers("a.b.c.d")
+	assert.Len(subscribers, 2)
+	for _, subscriber := range subscribers {
+		assert.Contains(sessions, subscriber)
+	}
 }
 
 func TestConfig(t *testing.T) {

--- a/matchbox_test.go
+++ b/matchbox_test.go
@@ -121,6 +121,33 @@ func TestMatchbox(t *testing.T) {
 	assert.Equal([]Subscriber{}, mb.Subscribers("x.a.a.a.y"))
 }
 
+// Mimic problem that Tom Deering is experiencing
+func TestInternalPoundSubscriber(t *testing.T) {
+	assert := assert.New(t)
+
+	// Works for Tom
+	//mb := New(NewAMQPConfig())
+	//sub1 := subscriber("Subcriber1")
+	//mb.Subscribe("*.b.#", sub1)
+	//sub2 := subscriber("Subscriber2")
+	//mb.Subscribe("*.b.*.d", sub2)
+	//subscribers := mb.Subscribers("a.b.c.d")
+	//sessions := []Subscriber{sub1, sub2}
+	//assert.Len(subscribers, 2)
+	//for _, subscriber := range subscribers {
+	//	assert.Contains(sessions, subscriber)
+	//}
+
+	// Does not work for Tom. He observed that sub1 does not seem to receive
+	// messages in this situation
+	mb := New(NewAMQPConfig())
+	sub1 := subscriber("Subcriber1")
+	mb.Subscribe("*.b.#", sub1)
+	sub2 := subscriber("Subscriber2")
+	mb.Subscribe("*.b.#.d", sub2)
+	assert.Equal([]Subscriber{sub2, sub1}, mb.Subscribers("a.b.c.d"))
+}
+
 func TestConfig(t *testing.T) {
 	assert := assert.New(t)
 	mb := New(&Config{Delimiter: "|", SingleWildcard: "$", ZeroOrMoreWildcard: "%"})


### PR DESCRIPTION
This fixes a bug (identified [here](https://github.com/Workiva/matchbox/pull/5)) where zero-or-more wildcard (#) subscribers on
internal, non-leaf nodes were not being included on subscriber lookups.

> Observed problem: I get messages on *.somePrefix.# unless I also subscribe to *.somePrefix.#.someSuffix. In this case, I no longer receive messages on *.somePrefix.#

@tomdeering-wf @stevenosborne-wf @brianshannan-wf @matthewgardner-wf @wesleybalvanz-wf 