### PR TITLE
Fix bug where subscriptions were lost

### DIFF
--- a/ctrie.go
+++ b/ctrie.go
@@ -135,6 +135,7 @@ func (c *cNode) updated(key string, sub Subscriber, gen *generation) *cNode {
 		for id, sub := range br.subs {
 			newBranch.subs[id] = sub
 		}
+		newBranch.iNode = br.iNode
 	}
 	branches[key] = newBranch
 	return &cNode{branches: branches, gen: gen}

--- a/matchbox_test.go
+++ b/matchbox_test.go
@@ -152,6 +152,22 @@ func TestInternalPoundSubscriber(t *testing.T) {
 	}
 }
 
+func TestChildParentSubscriber(t *testing.T) {
+	assert := assert.New(t)
+	mb := New(NewAMQPConfig())
+	sub1 := subscriber("sub1")
+	sub2 := subscriber("sub2")
+	sub3 := subscriber("sub3")
+
+	mb.Subscribe("foo.bar.baz.qux.1", sub1)
+	mb.Subscribe("foo.bar.baz.qux.2", sub2)
+	mb.Subscribe("foo.bar.baz.qux", sub3)
+
+	assert.Equal([]Subscriber{sub1}, mb.Subscribers("foo.bar.baz.qux.1"))
+	assert.Equal([]Subscriber{sub2}, mb.Subscribers("foo.bar.baz.qux.2"))
+	assert.Equal([]Subscriber{sub3}, mb.Subscribers("foo.bar.baz.qux"))
+}
+
 func TestConfig(t *testing.T) {
 	assert := assert.New(t)
 	mb := New(&Config{Delimiter: "|", SingleWildcard: "$", ZeroOrMoreWildcard: "%"})


### PR DESCRIPTION
This fixes a bug where subscriptions were being lost. The scenario was
subscribing to a topic, e.g. foo.bar.baz, then subscribing to a topic
which is a parent of the previous one, e.g. foo.bar. The latter
subscription resulted in the child being lost.

@alexandercampbell-wf @tayloranderson-wf @stevenosborne-wf @brianshannan-wf @wesleybalvanz-wf 